### PR TITLE
prevent connection lost on ethers provider

### DIFF
--- a/packages/cli/src/apps/coordinator/configurator/config-prompts/connect-web3.ts
+++ b/packages/cli/src/apps/coordinator/configurator/config-prompts/connect-web3.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
-import { WebSocketProvider, JsonRpcProvider } from '@ethersproject/providers'
+import { ethers } from 'ethers'
+import Web3WsProvider from 'web3-providers-ws'
 import Configurator, { Context, Menu } from '../configurator'
 
 export default class ConnectWeb3 extends Configurator {
@@ -7,11 +8,19 @@ export default class ConnectWeb3 extends Configurator {
 
   async run(context: Context): Promise<{ context: Context; next: number }> {
     console.log(chalk.blue('Connecting to the Ethereum network'))
-    const provider:
-      | WebSocketProvider
-      | JsonRpcProvider = this.base.provider.startsWith('ws')
-      ? new WebSocketProvider(this.base.provider)
-      : new JsonRpcProvider(this.base.provider)
+    const provider = new ethers.providers.Web3Provider(
+      new (Web3WsProvider as any)(this.base.provider, {
+        reconnect: {
+          delay: 2000,
+          auto: true,
+          onTimeout: false
+        },
+        clientConfig: {
+          keepalive: true,
+          keepaliveInterval: 30000,
+        },
+      }))
+
     async function waitConnection() {
       return new Promise<void>(async res => {
         if (await provider.ready) return res()


### PR DESCRIPTION
ethersjs does not have reconnecting feature on providers. so, when provider connection lost then workers of coordinator fall in deadlock.

Using `web3-provider-ws` for ethersjs provider is hacky way, but it is simpler than listening `close` event and adding more action in coordinator.

because we have been testing coordinator using a provider from web3js and it is quite reliable so far on main repository.

At some point, we should have to make stable web3 provider base on ethersjs for zkopru coordinator.