### PR TITLE
fix update url event handling error

### DIFF
--- a/packages/core/src/coordinator-manager.ts
+++ b/packages/core/src/coordinator-manager.ts
@@ -135,12 +135,12 @@ export class CoordinatorManager {
     burnAuction.on(filter, this.handleUrlUpdate)
   }
 
-  handleUrlUpdate: TypedListener<[string], { coordinatorAddr: string }> = async (
+  handleUrlUpdate: TypedListener<[string], { coordinator: string }> = async (
     _: string,
     event,
   ) => {
-    const { coordinatorAddr } = event.args
-    await this.updateUrl(coordinatorAddr)
+    const { coordinator } = event.args
+    await this.updateUrl(coordinator)
   }
 
   async stop() {

--- a/packages/core/src/coordinator-manager.ts
+++ b/packages/core/src/coordinator-manager.ts
@@ -6,7 +6,7 @@ import {
   BurnAuction__factory,
   ZkopruContract,
 } from '@zkopru/contracts'
-import { TypedEvent } from '@zkopru/contracts/typechain/common'
+import { TypedListener } from '@zkopru/contracts/typechain/common'
 import fetch from 'node-fetch'
 
 /**
@@ -135,12 +135,12 @@ export class CoordinatorManager {
     burnAuction.on(filter, this.handleUrlUpdate)
   }
 
-  async handleUrlUpdate(
+  handleUrlUpdate: TypedListener<[string], { coordinatorAddr: string }> = async (
     _: string,
-    event: TypedEvent<[string] & { coordinator: string }>,
-  ) {
-    const { coordinator } = event.args
-    await this.updateUrl(coordinator)
+    event,
+  ) => {
+    const { coordinatorAddr } = event.args
+    await this.updateUrl(coordinatorAddr)
   }
 
   async stop() {


### PR DESCRIPTION
the error message

```
/home/ubuntu/zkopru/packages/core/dist/coordinator-manager.js:136
            yield this.updateUrl(coordinator);
                       ^

TypeError: this.updateUrl is not a function
    at FragmentRunningEvent.<anonymous> (/home/ubuntu/zkopru/packages/core/dist/coordinator-manager.js:136:24)
    at Generator.next (<anonymous>)
    at /home/ubuntu/zkopru/packages/core/dist/coordinator-manager.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/ubuntu/zkopru/packages/core/dist/coordinator-manager.js:4:12)
    at FragmentRunningEvent.handleUrlUpdate (/home/ubuntu/zkopru/packages/core/dist/coordinator-manager.js:134:16)
    at Timeout._onTimeout (/home/ubuntu/zkopru/node_modules/@ethersproject/contracts/lib/index.js:497:31)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7
```

this method is called by contract event in `burnAuction` after a coordinator sends `updateUrl` tx.
but the `updateUrl` method is out of scope when the event listener calls in the coordinator-manager instance.
so I fixed with using an arrow function, which can access listeners